### PR TITLE
Fixed typo on paragraph #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Take note:
 
 * Many of the above fields can be empty. Most of the different systems using the tfrecords will only need a subset of the fields. 
 
-* The bounding box coordinates, part coordinates and areas need to be *normalized*. For the bounding boxes and parts this means that the x values have been divided by the width of the image, and the y values have been divided by the height of the image. This ensures that the pixel location can be recovered on any (aspect-perserved) resized version of the original image. The areas are normalized by they area of the image. 
+* The bounding box coordinates, part coordinates and areas need to be *normalized*. For the bounding boxes and parts this means that the x values have been divided by the width of the image, and the y values have been divided by the height of the image. This ensures that the pixel location can be recovered on any (aspect-preserved) resized version of the original image. The areas are normalized by they area of the image. 
 
 * The origin of an image is the top left. All pixel locations will be interpreted with respect to that origin. 
 


### PR DESCRIPTION
`perserved` > `preserved`